### PR TITLE
add dev container support with openscad and python preinstalled

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+	"build": { "dockerfile": "dockerfile" },
+	"features": {
+		"ghcr.io/devcontainers/features/python:1": {
+			"installTools": true,
+			"version": "latest"
+		}
+	},
+	
+	"customizations": {
+	},
+
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/devcontainers/base:bookworm
+
+RUN wget -qO- https://files.openscad.org/OBS-Repository-Key.pub | sudo tee /etc/apt/trusted.gpg.d/obs-openscad-nightly.asc \
+    && echo "deb https://download.opensuse.org/repositories/home:/t-paul/Debian_12/ ./" >> /etc/apt/sources.list.d/openscad.list \
+    && apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends openscad openscad-nightly

--- a/rbuild.py
+++ b/rbuild.py
@@ -20,12 +20,20 @@ if os.name == "posix":
     else:  # Assume Linux if not macOS
         print("Operating System: Linux")
         PATH_TO_OPENSCAD = '/usr/bin/openscad'
-        PATH_TO_OPENSCAD_NIGHTLY = '/snap/bin/openscad-nightly'
+        
+        if binary_exists(PATH_TO_OPENSCAD):
+            print(f"Binary found at {PATH_TO_OPENSCAD}")
+        else:
+            print(f"Binary not found at {PATH_TO_OPENSCAD}")
 
-    if binary_exists(PATH_TO_OPENSCAD):
-        print(f"Binary found at {PATH_TO_OPENSCAD}")
-    else:
-        print(f"Binary not found at {PATH_TO_OPENSCAD}")
+        if binary_exists('/snap/bin/openscad-nightly'):
+            print(f"Nightly binary found at {PATH_TO_OPENSCAD}")
+            PATH_TO_OPENSCAD_NIGHTLY = '/snap/bin/openscad-nightly'
+        elif binary_exists('/usr/bin/openscad-nightly'):
+            print(f"Nightly binary found at {PATH_TO_OPENSCAD}")
+            PATH_TO_OPENSCAD_NIGHTLY = '/usr/bin/openscad-nightly'
+        else:
+            print('Nightly binary not installed')
 
 elif os.name == "nt":  # Windows
     print("Operating System: Windows")


### PR DESCRIPTION
Added setup for a debian dev container with python, openscad and openscad-nightly preinstalled.
Updated rbuild.py to look in in both the /snap/bin and /usr/bin directories for the installed instance of openscad-nightly